### PR TITLE
only show tracked data, add age penalty

### DIFF
--- a/database.go
+++ b/database.go
@@ -46,7 +46,7 @@ func (ndb newsDatabase) init() {
 		"CREATE TABLE IF NOT EXISTS stories(id int primary key, by text not null, title text not null, url text not null, timestamp int not null);",
 		"CREATE TABLE IF NOT EXISTS dataset (id integer not null, score integer, descendants integer not null, submissionTime integer not null, sampleTime integer not null, topRank integer, newRank integer, bestRank integer, askRank integer, showRank integer);",
 		"CREATE INDEX IF NOT EXISTS dataset_sampletime_id ON dataset(sampletime, id);",
-		"CREATE TABLE IF NOT EXISTS attention(id int primary key, upvotes int, totalUpvotes int, totalComments int, submissionTime int, cumulativeAttention real, lastUpdateSampleTime int);",
+		"CREATE TABLE IF NOT EXISTS attention(id int primary key, upvotes int, cumulativeAttention real, lastUpdateSampleTime int);",
 	}
 
 	for _, s := range seedStatements {
@@ -95,7 +95,7 @@ func openNewsDatabase(sqliteDataDir string) (newsDatabase, error) {
 	}
 
 	{
-		sql := `INSERT INTO attention (id, upvotes, totalUpvotes, totalComments, submissionTime, cumulativeAttention, lastUpdateSampleTime) VALUES (?, ?, ?, ?, ?, ?, ?) ON CONFLICT DO UPDATE SET cumulativeAttention = cumulativeAttention + excluded.cumulativeAttention, upvotes = upvotes + excluded.upvotes, totalUpvotes = excluded.totalUpvotes, totalComments = excluded.totalComments, lastUpdateSampleTime = excluded.lastUpdateSampleTime`
+		sql := `INSERT INTO attention (id, upvotes, cumulativeAttention, lastUpdateSampleTime) VALUES (?, ?, ?, ?) ON CONFLICT DO UPDATE SET cumulativeAttention = cumulativeAttention + excluded.cumulativeAttention, upvotes = upvotes + excluded.upvotes, lastUpdateSampleTime = excluded.lastUpdateSampleTime`
 		ndb.upsertAttentionStatement, err = ndb.db.Prepare(sql)
 		if err != nil {
 			return ndb, err
@@ -122,8 +122,8 @@ func (ndb newsDatabase) insertDataPoint(d dataPoint) error {
 	return nil
 }
 
-func (ndb newsDatabase) upsertAttention(id int, deltaUpvotes int, totalUpvotes int, totalComments int, submissionTime int64, cumulativeAttention float64, lastUpdateSampleTime int64) error {
-	_, err := ndb.upsertAttentionStatement.Exec(id, deltaUpvotes, totalUpvotes, totalComments, submissionTime, cumulativeAttention, lastUpdateSampleTime)
+func (ndb newsDatabase) upsertAttention(id int, deltaUpvotes int, cumulativeAttention float64, lastUpdateSampleTime int64) error {
+	_, err := ndb.upsertAttentionStatement.Exec(id, deltaUpvotes, cumulativeAttention, lastUpdateSampleTime)
 	if err != nil {
 		return err
 	}

--- a/frontpage.go
+++ b/frontpage.go
@@ -42,7 +42,7 @@ const frontPageSQL = `
   join stories using(id)
   join dataset using(id)
   where sampleTime = (select max(sampleTime) from dataset)
-  order by quality / sqrt(unixepoch()-submissionTime) desc
+  order by quality / sqrt(3600 + unixepoch()-submissionTime) desc
   limit 90;
 `
 

--- a/frontpage.go
+++ b/frontpage.go
@@ -42,7 +42,7 @@ const frontPageSQL = `
   join stories using(id)
   join dataset using(id)
   where sampleTime = (select max(sampleTime) from dataset)
-  order by quality / sqrt(3600 + unixepoch()-submissionTime) desc
+  order by quality / pow(cast(unixepoch()-submissionTime as real)/3600 + 2, 1.2) desc
   limit 90;
 `
 
@@ -66,6 +66,12 @@ const frontPageSQL = `
    Now we want the quality, not log quality. With a little math, we get
 
    		q = (v/a)^(v/(v+k))
+
+   Age penalty ordering mimics the original HN formula:
+   pow(upvotes, 0.8) / pow(ageHours + 2, 1.8)
+
+   Assuming cumulativeAttention ~ ageHours^0.6, this becomes
+   upvotes / (cumulativeAttention * (ageHours + 2)^1.2)
 */
 
 //go:embed templates/*

--- a/frontpage.go
+++ b/frontpage.go
@@ -29,21 +29,21 @@ type story struct {
 }
 
 const frontPageSQL = `
-	with attentionWithAge as (
-		select *, unixepoch()-submissionTime as age
-		from attention
-		order by id desc
-		limit 3000
-	)
-	select
-		id, by, title, url, submissionTime, totalUpvotes, totalComments
-		, (upvotes + 2.2956)/(cumulativeAttention+2.2956) as quality 
-	from attentionWithAge join stories using(id)
-	order by 
-		quality desc
-	limit 90;
-
-*/
+  select
+    id
+    , by
+    , title
+    , url
+    , submissionTime
+    , score
+    , descendants
+    , (upvotes + 2.2956)/(cumulativeAttention+2.2956) as quality 
+  from attention
+  join stories using(id)
+  join dataset using(id)
+  where sampleTime = (select max(sampleTime) from dataset)
+  order by quality / sqrt(unixepoch()-submissionTime) desc
+  limit 90;
 `
 
 /* The Bayesian averaging constant/formula from bayesian-average-quality.R

--- a/rankcrawler.go
+++ b/rankcrawler.go
@@ -113,7 +113,7 @@ func rankCrawlerStep(ndb newsDatabase, client *hn.Client, logger leveledLogger) 
 	logger.Info("Inserting rank data", "nitems", len(items))
 	// get details for every unique story
 
-	var sitewideUpvotes int 
+	var sitewideUpvotes int
 	var deltaUpvotes = make([]int, len(items))
 
 ITEM:
@@ -160,7 +160,7 @@ ITEM:
 
 	}
 
-	logger.Debug("sitewideUpvotes", "value",sitewideUpvotes)
+	logger.Debug("sitewideUpvotes", "value", sitewideUpvotes)
 
 	var totalDeltaAttention float64
 	var totalAttentionShare float64
@@ -169,24 +169,23 @@ ITEM:
 
 		storyID := item.ID
 		ranks := ranksMap[storyID]
-		submissionTime := int64(item.Time().Unix())
 
 	RANKS:
 		for pageType, rank := range ranks {
 			if rank == 0 {
 				continue RANKS
 			}
-			d := accumulateAttention(ndb, logger, pageType, storyID, rank, sampleTime, deltaUpvotes[i], item.Score, item.Descendants, sitewideUpvotes, submissionTime)
+			d := accumulateAttention(ndb, logger, pageType, storyID, rank, sampleTime, deltaUpvotes[i], sitewideUpvotes)
 			totalDeltaAttention += d[0]
 			totalAttentionShare += d[1]
 		}
 		j = i
 	}
 
-	logger.Debug("Totals", 
-		"deltaAttention", totalDeltaAttention, 
-		"sitewideUpvotes", sitewideUpvotes, 
-		"totalAttentionShare", totalAttentionShare, 
+	logger.Debug("Totals",
+		"deltaAttention", totalDeltaAttention,
+		"sitewideUpvotes", sitewideUpvotes,
+		"totalAttentionShare", totalAttentionShare,
 		"dataPoints", j)
 
 	logger.Info("Successfully inserted rank data", "nitems", len(items))

--- a/seed
+++ b/seed
@@ -21,7 +21,7 @@ sq3 "$DB" 'CREATE TABLE stories(id int primary key, by text not null, title text
 sq3 "$DB" 'CREATE TABLE dataset (id integer not null, score integer, descendants integer not null, submissionTime integer not null, sampleTime integer not null, topRank integer, newRank integer, bestRank integer, askRank integer, showRank integer);'
 sq3 "$DB" 'CREATE INDEX dataset_sampletime_id ON dataset(sampletime, id);'
 
-sq3 "$DB" 'CREATE TABLE attention(id int primary key, upvotes int, totalUpvotes int, totalComments int, submissionTime int, cumulativeAttention real, lastUpdateSampleTime int);'
+sq3 "$DB" 'CREATE TABLE attention(id int primary key, upvotes int, cumulativeAttention real, lastUpdateSampleTime int);'
 
 echo "created $DB"
 


### PR DESCRIPTION
- Removes `totalUpvotes`, `totalComments`, `submissionTime` from `attention` table.
  This data is already contained in `dataset`
- The frontpage is only calculated for stories which appear in the latest `dataset` sample. This avoids flagged or deleted stories, which don't appear in the API anymore. The attention calculation only made sense for the 3 first pages anyways (max 90 ranks).
- Add an age penalty of `sqrt(ageSeconds)` to account for fatigue (@johnwarden please check if this makes sense to do this on the seconds value).

After merging this, we need to reinitialize the db.

closes #20 
closes #19 