### PR TITLE
speed up penalties.sql by only looking at last hour (#92)

### DIFF
--- a/sql/penalties.sql
+++ b/sql/penalties.sql
@@ -32,7 +32,7 @@ with latestScores as (
     , submissionTime > timestamp as resubmitted
    from dataset join stories using (id)
    -- where sampleTime = 1668791580
-   where sampleTime > (select max(sampleTime) from dataset) - 3600*24 -- look at last 24 hours
+   where sampleTime > (select max(sampleTime) from dataset) - 3600 -- look at last 24 hours
    and score > 3 -- story can't reach front page until score > 3
 ), 
 ranks as (
@@ -68,7 +68,7 @@ ranks as (
   -- get latest previous sample time for each story
   where dataset.sampleTime < (select max(sampleTime) from dataset)
   -- and dataset.sampleTime > (select max(sampleTime) from dataset) - 3600*24 
-  -- and dataSet.sampleTime > (select max(sampleTime) from dataset) - 3600
+  and dataSet.sampleTime > (select max(sampleTime) from dataset) - 3600
   group by 1
 )
 


### PR DESCRIPTION
this reduces the time on my machine from about 1s to about 110ms. Let's see what it does in production.
Currently this query is taking about 15s in production.
