### PR TITLE
Threshold for making front page is >= 3

### DIFF
--- a/frontpage.go
+++ b/frontpage.go
@@ -85,6 +85,7 @@ const frontPageSQL = `
 	  join dataset using(id)
 	  join parameters
 	  where sampleTime = (select max(sampleTime) from dataset)
+      and score >= 3
 	)
 	, unadjustedRanks as (
 		select

--- a/frontpage.go
+++ b/frontpage.go
@@ -80,7 +80,7 @@ const frontPageSQL = `
 			*
 			, timestamp as OriginalSubmissionTime
 			, (cumulativeUpvotes + priorWeight)/(cumulativeExpectedUpvotes + priorWeight) as quality
-			, cast((sampleTime-submissionTime)/3600 as real) as ageHours
+			, cast((sampleTime-submissionTime) as real)/3600 as ageHours
 	  from stories
 	  join dataset using(id)
 	  join parameters

--- a/sql/penalties.sql
+++ b/sql/penalties.sql
@@ -33,7 +33,7 @@ with latestScores as (
    from dataset join stories using (id)
    -- where sampleTime = 1668791580
    where sampleTime > (select max(sampleTime) from dataset) - 3600 -- look at last 24 hours
-   and score > 3 -- story can't reach front page until score > 3
+   and score >= 3 -- story can't reach front page until score >= 3
 ), 
 ranks as (
   select 

--- a/sql/penalties3.sql
+++ b/sql/penalties3.sql
@@ -9,7 +9,7 @@ with latestScores as (
    from dataset join stories using (id)
 --   where sampleTime > (select max(sampleTime) from dataset) - 3600
    where sampleTime = (select max(sampleTime) from dataset)
-   and score > 3
+   and score >= 3 -- story can't reach front page until score >= 3
 ) 
 
 select 

--- a/sql/qnranks.sql
+++ b/sql/qnranks.sql
@@ -10,7 +10,7 @@ with parameters as (select %f as priorWeight, %f as overallPriorWeight, %f as gr
 		, penalty
 	from dataset
 	where sampleTime = (select max(sampleTime) from dataset)
-	and score > 3
+	and score >= 3 -- story can't reach front page until score >= 3
 ),
 unadjustedRanks as (
   select 


### PR DESCRIPTION
- fix bug: frontpage stories weren't being sorted by qnRank field
- Threshold for making front page is >= 3
