### PR TITLE
Improvements to penalties calculation

### DIFF
--- a/database.go
+++ b/database.go
@@ -97,14 +97,7 @@ func (ndb newsDatabase) init() error {
 		}
 	}
 
-	previousCrawlViewSQL := readSQLSource("previous-crawl-view.sql")
-
-	_, err := ndb.db.Exec(previousCrawlViewSQL)
-	if err != nil {
-		return errors.Wrap(err, "executing previousCrawlViewSQL")
-	}
-
-	return errors.Wrap(err, "executing previousCrawlViewSQL")
+	return nil
 }
 
 func openNewsDatabase(sqliteDataDir string) (newsDatabase, error) {

--- a/postprocessing.go
+++ b/postprocessing.go
@@ -20,7 +20,7 @@ func (app app) crawlPostprocess(ctx context.Context, tx *sql.Tx) error {
 
 	var err error
 
-	for _, filename := range []string{"previous-crawl.sql", "previous-crawl-index.sql", "resubmissions.sql", "penalties.sql"} {
+	for _, filename := range []string{"previous-crawl.sql", "resubmissions.sql", "penalties.sql"} {
 		err = app.ndb.executeSQLFile(ctx, tx, filename)
 		if err != nil {
 			return err
@@ -30,11 +30,6 @@ func (app app) crawlPostprocess(ctx context.Context, tx *sql.Tx) error {
 	err = app.updateQNRanks(ctx, tx)
 	if err != nil {
 		return errors.Wrap(err, "updateQNRanks")
-	}
-
-	_, err = tx.ExecContext(ctx, "drop table previousCrawl")
-	if err != nil {
-		return errors.Wrap(err, "dropping previousCrawl temporary table")
 	}
 
 	app.logger.Info("Finished crawl postprocessing", slog.Duration("elapsed", time.Since(t)))

--- a/postprocessing.go
+++ b/postprocessing.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/pkg/errors"
+	"golang.org/x/exp/slog"
+)
+
+const qnRankFormulaSQL = "pow((cumulativeUpvotes + overallPriorWeight)/(cumulativeExpectedUpvotes + overallPriorWeight) * ageHours, 0.8) / pow(ageHours + 2, gravity) desc"
+
+func (app app) crawlPostprocess(ctx context.Context, tx *sql.Tx) error {
+	t := time.Now()
+	defer crawlPostprocessingDuration.UpdateDuration(t)
+
+	var err error
+
+	for _, filename := range []string{"previous-crawl.sql", "previous-crawl-index.sql", "resubmissions.sql", "penalties.sql"} {
+		err = app.ndb.executeSQLFile(ctx, tx, filename)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = app.updateQNRanks(ctx, tx)
+	if err != nil {
+		return errors.Wrap(err, "updateQNRanks")
+	}
+
+	_, err = tx.ExecContext(ctx, "drop table previousCrawl")
+	if err != nil {
+		return errors.Wrap(err, "dropping previousCrawl temporary table")
+	}
+
+	app.logger.Info("Finished crawl postprocessing", slog.Duration("elapsed", time.Since(t)))
+
+	return err
+}
+
+var qnRanksSQL = readSQLSource("qnranks.sql")
+
+func (app app) updateQNRanks(ctx context.Context, tx *sql.Tx) error {
+	t := time.Now()
+
+	d := defaultFrontPageParams
+	sql := fmt.Sprintf(qnRanksSQL, d.PriorWeight, d.OverallPriorWeight, d.Gravity, d.PenaltyWeight, qnRankFormulaSQL)
+
+	stmt, err := tx.Prepare(sql)
+	if err != nil {
+		return errors.Wrap(err, "preparing updateQNRanksSQL")
+	}
+
+	_, err = stmt.ExecContext(ctx)
+
+	app.logger.Debug("Finished executing updateQNRanks", slog.Duration("elapsed", time.Since(t)))
+
+	return errors.Wrap(err, "executing updateQNRanksSQL")
+}
+
+func readSQLSource(filename string) string {
+	f, err := resources.Open("sql/" + filename)
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+	buf := bytes.NewBuffer(nil)
+	_, err = io.Copy(buf, f)
+	if err != nil {
+		panic(err)
+	}
+
+	return buf.String()
+}
+
+func (ndb newsDatabase) executeSQLFile(ctx context.Context, tx *sql.Tx, filename string) error {
+	sql := readSQLSource(filename)
+
+	stmt, err := tx.Prepare(sql)
+	if err != nil {
+		return errors.Wrapf(err, "preparing SQL in file %s", filename)
+	}
+
+	_, err = stmt.ExecContext(ctx)
+
+	return errors.Wrapf(err, "executing SQL in file %s", filename)
+}

--- a/prometheus.go
+++ b/prometheus.go
@@ -49,10 +49,9 @@ func prometheusMiddleware[P any](routeName string, h httperror.XHandler[P]) http
 
 	return func(w http.ResponseWriter, r *http.Request, p P) error {
 		startTime := time.Now()
+		defer requestDuration.UpdateDuration(startTime)
 
 		err := h.Serve(w, r, p)
-
-		requestDuration.UpdateDuration(startTime)
 
 		return err
 	}

--- a/rankcrawler.go
+++ b/rankcrawler.go
@@ -105,6 +105,7 @@ func (app app) crawl(ctx context.Context, tx *sql.Tx) (int, error) {
 	logger := app.logger
 
 	t := time.Now()
+	defer crawlDuration.UpdateDuration(t)
 	sampleTime := t.Unix()
 
 	storyRanks, err := app.getRanksFromAPI(ctx)
@@ -291,7 +292,6 @@ STORY:
 		}
 	}
 
-	crawlDuration.UpdateDuration(t)
 	logger.Info("Finished crawl",
 		"nitems", len(stories), slog.Duration("elapsed", time.Since(t)),
 		"deltaExpectedUpvotes", sitewideDeltaExpectedUpvotes,

--- a/sql/penalties.sql
+++ b/sql/penalties.sql
@@ -32,15 +32,15 @@ with latestScores as (
     , submissionTime > timestamp as resubmitted
    from dataset join stories using (id)
    -- where sampleTime = 1668791580
-   where sampleTime > (select max(sampleTime) from dataset) - 3600 -- look at last 24 hours
+   where sampleTime > (select max(sampleTime) from dataset) - 3600 -- look at last hour
    and score >= 3 -- story can't reach front page until score >= 3
 ), 
 ranks as (
   select 
     *
     , ifnull(topRank,91) as rank
-    , count(*) filter (where not resubmitted and ageApprox < 3600*24 and not job and upvotes > 0 and topRank is not null) over (partition by sampleTime order by rankingScore desc) as expectedRankFiltered
-    , count(*) filter (where not resubmitted and ageApprox < 3600*24 and not job and upvotes > 0 and topRank is not null) over (partition by sampleTime order by topRank nulls last) as rankFiltered
+    , count(*) filter (where  ageApprox < 3600*24 and not job and upvotes > 0 and topRank is not null) over (partition by sampleTime order by rankingScore desc) as expectedRankFiltered
+    , count(*) filter (where  ageApprox < 3600*24 and not job and upvotes > 0 and topRank is not null) over (partition by sampleTime order by topRank nulls last) as rankFiltered
   from latestScores
   order by rank
 )

--- a/sql/previous-crawl-index.sql
+++ b/sql/previous-crawl-index.sql
@@ -1,1 +1,0 @@
-create index previousCrawl_id_idx on previousCrawl (id);

--- a/sql/previous-crawl-index.sql
+++ b/sql/previous-crawl-index.sql
@@ -1,0 +1,1 @@
+create index previousCrawl_id_idx on previousCrawl (id);

--- a/sql/previous-crawl.sql
+++ b/sql/previous-crawl.sql
@@ -2,7 +2,7 @@
 -- It is a bit tricky because the sampleTime may be different for each story, because
 -- Some stories may appear and disappear from crawl results if they fall off the front page and reappear.
 
-create temporary table previousCrawl as
+create table previousCrawl as
 with latest as (
   select * from dataset
   where sampleTime = (select max(sampleTime) from dataset)

--- a/sql/previous-crawl.sql
+++ b/sql/previous-crawl.sql
@@ -2,7 +2,7 @@
 -- It is a bit tricky because the sampleTime may be different for each story, because
 -- Some stories may appear and disappear from crawl results if they fall off the front page and reappear.
 
-create table previousCrawl as
+create view if not exists previousCrawl as
 with latest as (
   select * from dataset
   where sampleTime = (select max(sampleTime) from dataset)

--- a/storyplot-data.go
+++ b/storyplot-data.go
@@ -124,7 +124,7 @@ func upvotesDatapoints(ndb newsDatabase, storyID int) ([][]any, error) {
 		var upvotes int
 		var expectedUpvotes float64
 		var penalty float64
-		var currentPenalty float64
+		var currentPenalty sql.NullFloat64
 
 		err = rows.Scan(&sampleTime, &upvotes, &expectedUpvotes, &penalty, &currentPenalty)
 
@@ -139,7 +139,7 @@ func upvotesDatapoints(ndb newsDatabase, storyID int) ([][]any, error) {
 			expectedUpvotes,
 			(float64(upvotes) + priorWeight) / float64(expectedUpvotes+priorWeight),
 			penalty,
-			currentPenalty,
+			currentPenalty.Float64,
 		}
 		i++
 	}

--- a/templates/upvotesPlot.js.tmpl
+++ b/templates/upvotesPlot.js.tmpl
@@ -67,8 +67,8 @@ function upvotesPlot() {
       viewWindow: 'pretty',
     },
     series: {
-      0: {lineWidth: 2, lineDashStyle: [4,4], pointSize: 5},
       1: {lineWidth: 3, curveType: 'function'},
+      0: {lineWidth: 2, lineDashStyle: [4,4], pointSize: 5},
     },
 
     // we want a line to be drawn over intervals where the upvotes is null

--- a/watch.sh
+++ b/watch.sh
@@ -1,1 +1,1 @@
-ls *.go **/**.tmpl **/**.sql | entr -ncr sh -c 'go install; go run *.go | humanlog' 
+ls *.go **/**.tmpl **/**.sql | entr -ncr sh -c 'go install; go run *.go' 


### PR DESCRIPTION
- undo accidentally committed change to watch.sh
- include resubmitted stories in penalties calculation now that we have approximate resubmission time
- go back to previousCrawl as a view
- more refinements to penalties calculation (#75)
