### PR TITLE
Improvements to Penalties Calculation

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -64,7 +64,7 @@ type retryableHTTPClientloggerWrapper struct {
 }
 
 func (l retryableHTTPClientloggerWrapper) Error(msg string, keysAndValues ...interface{}) {
-	l.Logger.Error(msg, nil, keysAndValues...)
+	l.Logger.Error("retryableHTTPClient: "+msg, nil, keysAndValues...)
 }
 
 func (l retryableHTTPClientloggerWrapper) Debug(msg string, keysAndValues ...interface{}) {

--- a/postprocessing.go
+++ b/postprocessing.go
@@ -20,7 +20,7 @@ func (app app) crawlPostprocess(ctx context.Context, tx *sql.Tx) error {
 
 	var err error
 
-	for _, filename := range []string{"previous-crawl.sql", "previous-crawl-index.sql", "resubmissions.sql", "penalties.sql"} {
+	for _, filename := range []string{"previous-crawl.sql", "resubmissions.sql", "penalties.sql"} {
 		err = app.ndb.executeSQLFile(ctx, tx, filename)
 		if err != nil {
 			return err
@@ -30,11 +30,6 @@ func (app app) crawlPostprocess(ctx context.Context, tx *sql.Tx) error {
 	err = app.updateQNRanks(ctx, tx)
 	if err != nil {
 		return errors.Wrap(err, "updateQNRanks")
-	}
-
-	_, err = tx.ExecContext(ctx, "drop table previousCrawl")
-	if err != nil {
-		return errors.Wrap(err, "dropping previousCrawl temporary table")
 	}
 
 	app.logger.Info("Finished crawl postprocessing", slog.Duration("elapsed", time.Since(t)))

--- a/sql/penalties.sql
+++ b/sql/penalties.sql
@@ -32,15 +32,15 @@ with latestScores as (
     , submissionTime > timestamp as resubmitted
    from dataset join stories using (id)
    -- where sampleTime = 1668791580
-   where sampleTime > (select max(sampleTime) from dataset) - 3600 -- look at last 24 hours
+   where sampleTime > (select max(sampleTime) from dataset) - 3600 -- look at last hour
    and score >= 3 -- story can't reach front page until score >= 3
 ), 
 ranks as (
   select 
     *
     , ifnull(topRank,91) as rank
-    , count(*) filter (where not resubmitted and ageApprox < 3600*24 and not job and upvotes > 0 and topRank is not null) over (partition by sampleTime order by rankingScore desc) as expectedRankFiltered
-    , count(*) filter (where not resubmitted and ageApprox < 3600*24 and not job and upvotes > 0 and topRank is not null) over (partition by sampleTime order by topRank nulls last) as rankFiltered
+    , count(*) filter (where  ageApprox < 3600*24 and not job and upvotes > 0 and topRank is not null) over (partition by sampleTime order by rankingScore desc) as expectedRankFiltered
+    , count(*) filter (where  ageApprox < 3600*24 and not job and upvotes > 0 and topRank is not null) over (partition by sampleTime order by topRank nulls last) as rankFiltered
   from latestScores
   order by rank
 )

--- a/sql/previous-crawl-index.sql
+++ b/sql/previous-crawl-index.sql
@@ -1,1 +1,0 @@
-create index previousCrawl_id_idx on previousCrawl (id);

--- a/sql/previous-crawl.sql
+++ b/sql/previous-crawl.sql
@@ -2,7 +2,7 @@
 -- It is a bit tricky because the sampleTime may be different for each story, because
 -- Some stories may appear and disappear from crawl results if they fall off the front page and reappear.
 
-create table previousCrawl as
+create view if not exists previousCrawl as
 with latest as (
   select * from dataset
   where sampleTime = (select max(sampleTime) from dataset)

--- a/watch.sh
+++ b/watch.sh
@@ -1,1 +1,1 @@
-ls *.go **/**.tmpl **/**.sql | entr -ncr sh -c 'go install; go run *.go | humanlog' 
+ls *.go **/**.tmpl **/**.sql | entr -ncr sh -c 'go install; go run *.go' 


### PR DESCRIPTION
- undo accidentally committed change to watch.sh
- include resubmitted stories in penalties calculation now that we have approximate resubmission time (#75)
- go back to previousCrawl as a view
- more refinements to penalties calculation (#75)
- more detail in retryable http client logger output
