### PR TITLE
Tweaks to penalties and charts

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,6 +1,6 @@
 export SQLITE_DATA_DIR=data
 export CACHE_SIZE=100
-
+export LISTEN_ADDRESS=127.0.0.1
 
 echo "Successfully loaded .envrc"
 

--- a/frontpage.go
+++ b/frontpage.go
@@ -71,7 +71,7 @@ func (p FrontPageParams) String() string {
 	return fmt.Sprintf("%#v", p)
 }
 
-var defaultFrontPageParams = FrontPageParams{2.2956, 5.0, 1.4, 2}
+var defaultFrontPageParams = FrontPageParams{2.2956, 5.0, 1.4, 1.0}
 
 const frontPageSQL = `
 	with parameters as (select %f as priorWeight, %f as overallPriorWeight, %f as gravity, %f as penaltyWeight)

--- a/httpserver.go
+++ b/httpserver.go
@@ -48,11 +48,6 @@ func (app app) httpServer(onPanic func(error)) *http.Server {
 	router.GET("/new", middleware("new", l, onPanic, app.frontpageHandler("new")))
 	router.GET("/stats", middleware("stats", l, onPanic, app.statsHandler()))
 
-	router.GET("/plots/ranks.json", middleware("ranks-plotdata", l, onPanic, app.ranksDataJSON()))
-	router.GET("/plots/upvotes.json", middleware("upvotes-plotdata", l, onPanic, app.upvotesDataJSON()))
-	router.GET("/plots/upvoterate.json", middleware("upvoterate-plotdata", l, onPanic, app.upvoteRateDataJSON()))
-	router.GET("/plots/penalty.json", middleware("penalty-plotdata", l, onPanic, app.penaltyDataJSON()))
-
 	server.Handler = app.cacheAndCompressMiddleware(router)
 
 	return server

--- a/httpserver.go
+++ b/httpserver.go
@@ -29,13 +29,15 @@ func (app app) httpServer(onPanic func(error)) *http.Server {
 		port = "8080"
 	}
 
+	listenAddress := os.Getenv("LISTEN_ADDRESS")
+
 	staticRoot, err := fs.Sub(staticFS, "static")
 	if err != nil {
 		LogFatal(l, "fs.Sub", err)
 	}
 
 	server := &http.Server{
-		Addr:              ":" + port,
+		Addr:              listenAddress + ":" + port,
 		WriteTimeout:      writeTimeout,
 		ReadHeaderTimeout: readHeaderTimeout,
 	}

--- a/prometheus.go
+++ b/prometheus.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/VictoriaMetrics/metrics"
@@ -31,8 +32,10 @@ func servePrometheusMetrics() func(ctx context.Context) error {
 		metrics.WritePrometheus(w, true)
 	})
 
+	listenAddress := os.Getenv("LISTEN_ADDRESS")
+
 	s := &http.Server{
-		Addr:    ":9091",
+		Addr:    listenAddress + ":9091",
 		Handler: mux,
 	}
 

--- a/rankcrawler.go
+++ b/rankcrawler.go
@@ -144,7 +144,7 @@ func (app app) crawl(ctx context.Context, tx *sql.Tx) (int, error) {
 
 		t := time.Now()
 
-		ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
+		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
 
 		// get story details
@@ -316,7 +316,7 @@ func (app app) getRanksFromAPI(ctx context.Context) (map[int]ranksArray, error) 
 	for pageType := 0; pageType < len(pageTypes); pageType++ {
 		pageTypeName := pageTypes[pageType]
 
-		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
 		defer cancel()
 
 		storyIDs, err := client.Stories(ctx, pageTypeName)

--- a/sql/penalties.sql
+++ b/sql/penalties.sql
@@ -30,10 +30,9 @@ with latestScores as (
   select 
     *
     , score-1 as upvotes
-    , pow(score-1, 0.8) / pow(cast(sampleTime - timestamp as real)/3600+2, 1.8) as rankingScore -- pre-penalty HN ranking formula
+    , pow(score-1, 0.8) / pow(cast(sampleTime - submissionTime as real)/3600+2, 1.8) as rankingScore -- pre-penalty HN ranking formula
     , submissionTime > timestamp as resubmitted
    from dataset join stories using (id)
-   -- where sampleTime = 1668791580
    where sampleTime > (select max(sampleTime) from dataset) - 3600 -- look at last hour
    and score >= 3 -- story can't reach front page until score >= 3
 ), 

--- a/sql/penalties.sql
+++ b/sql/penalties.sql
@@ -40,8 +40,8 @@ ranks as (
   select 
     *
     , ifnull(topRank,91) as rank
-    , count(*) filter (where  ageApprox < 3600*24 and not job and upvotes > 0 and topRank is not null) over (partition by sampleTime order by rankingScore desc) as expectedRankFiltered
-    , count(*) filter (where  ageApprox < 3600*24 and not job and upvotes > 0 and topRank is not null) over (partition by sampleTime order by topRank nulls last) as rankFiltered
+    , count(*) filter (where ageApprox < 3600*24 and topRank is not null) over (partition by sampleTime order by rankingScore desc) as expectedRankFiltered
+    , count(*) filter (where ageApprox < 3600*24 and topRank is not null) over (partition by sampleTime order by topRank nulls last) as rankFiltered
   from latestScores
   order by rank
 )
@@ -69,6 +69,7 @@ update dataset as d
     currentPenalty = log(rankFiltered) - log(expectedRankFiltered)
     , penalty =
       case 
+        when resubmitted then 0
         when numRows < 30 then
           -- If we have less than 60 values in our moving average window,
           -- calculate the moving average as if we had 60 values but the 

--- a/statspage.go
+++ b/statspage.go
@@ -18,6 +18,9 @@ type StatsPageData struct {
 	StatsPageParams
 	EstimatedUpvoteRate int
 	Story               Story
+	RanksPlotData       [][]any
+	UpvotesPlotData     [][]any
+	PenaltyPlotData     [][]any
 }
 
 func (d StatsPageData) IsQualityPage() bool {
@@ -48,6 +51,24 @@ func statsPage(ndb newsDatabase, w io.Writer, r *http.Request, params StatsPageP
 		EstimatedUpvoteRate: 1.0,
 		Story:               s,
 	}
+
+	ranks, err := rankDatapoints(ndb, params.StoryID)
+	if err != nil {
+		return errors.Wrap(err, "rankDatapoints")
+	}
+	d.RanksPlotData = ranks
+
+	upvotes, err := upvotesDatapoints(ndb, params.StoryID)
+	if err != nil {
+		return errors.Wrap(err, "upvotesDatapoints")
+	}
+	d.UpvotesPlotData = upvotes
+
+	penalty, err := penaltyDatapoints(ndb, params.StoryID)
+	if err != nil {
+		return errors.Wrap(err, "penaltyDatapoints")
+	}
+	d.PenaltyPlotData = penalty
 
 	err = templates.ExecuteTemplate(w, "stats.html.tmpl", d)
 

--- a/templates/penaltyPlot.js.tmpl
+++ b/templates/penaltyPlot.js.tmpl
@@ -1,49 +1,28 @@
 var penaltyData
 
-function drawPenaltyPlot(submissionTime) {
-
-  var plotDiv = document.getElementById('penalty_plot_div')
-
-  if (penaltyData !== undefined) {
-    return penaltyPlot()
-  }
-
-  getJSON('/plots/penalty.json?id={{.ID}}',
-    function(err, dataPoints) {
-      plotDiv.classList.remove("spinner")
-      if (err !== null) {
-        plotDiv.innerHTML = "error fetching chart data"
-      } else {
-        var lastRank = null
-        for (var i = 0; i < dataPoints.length; i++) { 
-
-          var rank = dataPoints[i][3]
-
-          var lastRankIsOffChart = ( lastRank == 91 || lastRank == null )
-          var nextRankIsOnChart = ( i+1 < dataPoints.length && dataPoints[i+1][3] != null && dataPoints[i+1][3] != 91)
-
-          if ( rank == 91 && (lastRankIsOffChart && !nextRankIsOnChart) ) {
-            rank = null
-          } else {
-            lastRank = rank
-          } 
-
-          dataPoints[i] = [
-            (dataPoints[i][0] - submissionTime)/3600, 
-            dataPoints[i][1] || null, 
-            dataPoints[i][2] || null,
-            rank
-          ]
-        }
-
-        penaltyData = dataPoints
-        penaltyPlot()
-      }
+function preparePenaltyPlotData(dataPoints, submissionTime) {
+  var results = []
+  var lastRank = null
+  for (var i = 0; i < dataPoints.length; i++) {
+    var rank = dataPoints[i][3]
+    var lastRankIsOffChart = ( lastRank == 91 || lastRank == null )
+    var nextRankIsOnChart = ( i+1 < dataPoints.length && dataPoints[i+1][3] != null && dataPoints[i+1][3] != 91)
+    if ( rank == 91 && (lastRankIsOffChart && !nextRankIsOnChart) ) {
+      rank = null
+    } else {
+      lastRank = rank
     }
-  )
+    results[i] = [
+      (dataPoints[i][0] - submissionTime)/3600,
+      dataPoints[i][1] || null,
+      dataPoints[i][2] || null,
+      rank
+    ]
+  }
+  return results
 }
 
-function penaltyPlot() {
+function penaltyPlot(penaltyData, submissionTime, startTime, endTime) {
 
   var plotDiv = document.getElementById('penalty_plot_div')
 
@@ -53,7 +32,7 @@ function penaltyPlot() {
   data.addColumn('number', 'Current Estimated Penalty');
   data.addColumn('number', 'HN Rank');
 
-  data.addRows(penaltyData);
+  data.addRows(preparePenaltyPlotData(penaltyData, submissionTime));
 
   var ageFormatter = new ageFormat()
   ageFormatter.format(data, 0);
@@ -65,7 +44,8 @@ function penaltyPlot() {
       title: 'Age [hours]',
       logScale: false,
       viewWindow: {
-        min: 0,
+        min: (startTime-submissionTime)/3600,
+        max: (endTime-submissionTime)/3600,
       }
     },
 
@@ -95,9 +75,9 @@ function penaltyPlot() {
 
     lineWidth: 3,
     colors: ['red', '#b32b6c', '#FF6600'],
-    chartArea:{left:80,top:50, bottom: 80, right: 80},
+    chartArea:{left:80, top:50, bottom: 80, right: 80},
+    height: 350,
     legend: { position: 'bottom' },
-    height: 400,
     crosshair: { trigger: 'both' },
     title: "Penalties",
   };

--- a/templates/ranksPlot.js.tmpl
+++ b/templates/ranksPlot.js.tmpl
@@ -1,53 +1,36 @@
-var ranksData
 
-function drawRanksPlot(submissionTime) {
-  if (ranksData !== undefined) {
-    return ranksPlot()
-  }
+function prepareRanksPlotData(dataPoints, submissionTime) {
 
-  var plotDiv = document.getElementById('ranks_plot_div')
+  var results = []
 
-  getJSON('/plots/ranks.json?id={{.ID}}',
-    function(err, dataPoints) {
+  // plot only age, qntop, hntop, new, and best
+  // so 5 columns of data (x axis plus 4 ranks) 
+  var n = 5 
+  var lastValue = [null,null,null,null,null]
+  for (var i = 0; i < dataPoints.length; i++) { 
 
-      plotDiv.classList.remove("spinner")
-      if (err !== null) {
-        plotDiv.innerHTML = "error fetching chart data"
+    var p = dataPoints[i].slice(0, n)
+
+    // convert timestamp to age in hours
+    p[0] = (p[0] - submissionTime)/3600
+
+    // only plot a single point when a line leaves/exits the chart from below rank 91
+    for (var j = 1; j < n; j++) {
+      var lastValueIsOffChart = ( lastValue[j] == 91 || lastValue[j] == null )
+      var nextValueIsOnChart = ( i+1 < dataPoints.length && dataPoints[i+1][j] != null && dataPoints[i+1][j] != 91)
+
+      if ( p[j] == 91 && (lastValueIsOffChart && !nextValueIsOnChart) ) {
+        p[j] = null
       } else {
-
-
-        // plot only age, qntop, hntop, new, and best
-        // so 5 columns of data (x axis plus 4 ranks) 
-        var n = 5 
-        var lastValue = [null,null,null,null,null]
-        for (var i = 0; i < dataPoints.length; i++) { 
-
-          var p = dataPoints[i].slice(0, n)
-
-          // convert timestamp to age in hours
-          p[0] = (p[0] - submissionTime)/3600
-
-          // only plot a single point when a line leaves/exits the chart from below rank 91
-          for (var j = 1; j < n; j++) {
-            var lastValueIsOffChart = ( lastValue[j] == 91 || lastValue[j] == null )
-            var nextValueIsOnChart = ( i+1 < dataPoints.length && dataPoints[i+1][j] != null && dataPoints[i+1][j] != 91)
-
-            if ( p[j] == 91 && (lastValueIsOffChart && !nextValueIsOnChart) ) {
-              p[j] = null
-            } else {
-              lastValue[j] = p[j]
-            } 
-          }
-          dataPoints[i] = p
-        }
-        ranksData = dataPoints
-        ranksPlot()
-      }
+        lastValue[j] = p[j]
+      } 
     }
-  )
+    results[i] = p
+  }
+  return results
 }
 
-function ranksPlot() {
+function ranksPlot(dataPoints, submissionTime, startTime, endTime) {
   var plotDiv = document.getElementById('ranks_plot_div')
 
   var data = new google.visualization.DataTable();
@@ -57,15 +40,8 @@ function ranksPlot() {
   data.addColumn('number', 'New Rank');
   data.addColumn('number', 'Best Rank');
 
-  // these lines add too much noise to the plot and they
-  // have little influence on upvotes and thus on understanding
-  // story performance
-  // data.addColumn('number', 'Ask HN');
-  // data.addColumn('number', 'Show HN');
+  data.addRows(prepareRanksPlotData(dataPoints, submissionTime));
 
-  data.addRows(ranksData);
-
-  //var ageFormatter = new google.visualization.NumberFormat({suffix: ' hours old'});
   var ageFormatter = new ageFormat();
   
   ageFormatter.format(data, 0);
@@ -85,7 +61,8 @@ function ranksPlot() {
       title: 'Age [hours]',
       logScale: false,
       viewWindow: {
-        min: 0,
+        min: (startTime-submissionTime)/3600,
+        max: (endTime-submissionTime)/3600,
       }
     },
     vAxis: {
@@ -111,9 +88,9 @@ function ranksPlot() {
     lineDashStyle: [4,4],
     lineWidth: 2,
     colors: ['#0089F4', '#FF6600', "#AF7FDF", "#6FAEAE", "green","pink"],
-    chartArea:{left:80, top:50, bottom: 80, right: 20},
+    chartArea:{left:80, top:50, bottom: 80, right: 80},
+    height: 350,
     legend: { position: 'bottom' },
-    height: 400,
     crosshair: { trigger: 'both' },
     title: "Rank",
   };

--- a/templates/stats.html.tmpl
+++ b/templates/stats.html.tmpl
@@ -33,7 +33,7 @@
 
 <script>
 
-{{template "storyplots.js.tmpl" .Story}}
+{{template "storyplots.js.tmpl" .}}
 
 </script>
 
@@ -55,7 +55,7 @@
 
 <div id="storyplots">
 
-  <div id="ranks_plot_div" class="spinner"></div>
+  <div id="ranks_plot_div"></div>
   <div class="plot-description">
     This chart shows the history of this story's rank on <a href="/" style="color: #0089F4; font-weight: bold;">Quality News</a> compared to its rank on 
     the Hacker News <a href="https://news.ycombinator.com/" style="color: #FF6600; font-weight: bold;">Front Page</a>,
@@ -63,24 +63,28 @@
     and <a href="https://news.ycombinator.com/best" style="color: #6FAEAE; font-weight: bold;">"Best"</a> Page.
   </div>
 
+  <hr/>
 
-  <div id="upvotes_plot_div" class="spinner"></div>
+  <div id="upvotes_plot_div"></div>
   <div class="plot-description">
     This chart shows the history of this story's <span style="color: #55cccc; font-weight: bold;">upvotes</span> compared to the <span style="color: black; font-weight: bold">expected upvotes</span> for stories shown at the same ranks and times. See the <a href="https://github.com/social-protocols/news#about">about page</a> for further details.
   </div>
 
+  <hr/>
 
-
-  <div id="upvoterate_plot_div" class="spinner"></div>
+  <div id="upvoterate_plot_div"></div>
   <div class="plot-description">
     This chart shows the history of this story's <span style="color: #0089F4; font-weight: bold;">estimated true upvote rate</span>: the predicted long-term ratio of upvotes to expected upvotes. See the <a href="https://github.com/social-protocols/news#about">about page</a> for further details.
   </div>
 
-  <div id="penalty_plot_div" class="spinner"></div>
+  <hr/>
+
+  <div id="penalty_plot_div"></div>
   <div class="plot-description">
-    This chart shows a history of the story's estimated <span style="color: #b32b6c; font-weight: bold;">current penalty</span> based on the discrepancy between the story's <span style="color: #FF6600; font-weight: bold;">HN rank</span> and its expected rank based on the published ranking formula. A factor based on the moving <span style="color: red; font-weight: bold;">average estimated penalty</span> is then applied to the QN ranking score.
+    This chart shows the history of the story's estimated <span style="color: #b32b6c; font-weight: bold;">current penalty</span> based on the discrepancy between the story's <span style="color: #FF6600; font-weight: bold;">HN rank</span> and its expected rank based on the published ranking formula. A factor based on the moving <span style="color: red; font-weight: bold;">average estimated penalty</span> is applied to the QN ranking score.
   </div>
 
+  <hr/>
 
 </div>
 </div>

--- a/templates/storyplots.js.tmpl
+++ b/templates/storyplots.js.tmpl
@@ -5,11 +5,23 @@ google.charts.setOnLoadCallback(drawCharts);
 
 window.addEventListener('resize', drawCharts, false);
 
+var submissionTime = {{.Story.SubmissionTime}};
+
+var ranksPlotData = {{.RanksPlotData}};
+var upvotesPlotData = {{.UpvotesPlotData}};
+var upvoteRatePlotData = upvotesPlotData; //same data
+var penaltyPlotData = {{.PenaltyPlotData}};
+
 function drawCharts() {
-  drawRanksPlot({{.SubmissionTime}})
-  drawUpvotesPlot({{.SubmissionTime}})
-  drawUpvoteRatePlot({{.SubmissionTime}})
-  drawPenaltyPlot({{.SubmissionTime}})
+
+  // make all charts have the same x-axis range as the ranks plot chart
+  var startTime = ranksPlotData[0][0]
+  var endTime = ranksPlotData[ranksPlotData.length - 1][0]
+
+  ranksPlot(ranksPlotData, submissionTime, startTime, endTime)
+  upvotesPlot(upvotesPlotData, submissionTime, startTime, endTime)
+  upvoteRatePlot(upvoteRatePlotData, submissionTime, startTime, endTime)
+  penaltyPlot(penaltyPlotData, submissionTime, startTime, endTime)
 }
 
 // how rank is displayed when hovering over a datapoint
@@ -33,7 +45,7 @@ class ageFormat {
 
       // We converted the sample time to an age in hours for display on the X axis
       // But when we hover we want to see the original sample time.
-      var timeStamp = {{.SubmissionTime}} + ageHours * 3600
+      var timeStamp = {{.Story.SubmissionTime}} + ageHours * 3600
 
       var d = new Date(0); // The 0 there is the key, which sets the date to the epoch
       d.setUTCSeconds(timeStamp);

--- a/templates/upvoteRatePlot.js.tmpl
+++ b/templates/upvoteRatePlot.js.tmpl
@@ -1,32 +1,8 @@
-var upvoteRateData
-
-function drawUpvoteRatePlot(submissionTime) {
-
-  var plotDiv = document.getElementById('upvoterate_plot_div')
-
-  if (upvoteRateData !== undefined) {
-    return upvoteRatePlot()
-  }
-
-  getJSON('/plots/upvoterate.json?id={{.ID}}',
-    function(err, dataPoints) {
-      plotDiv.classList.remove("spinner")
-      if (err !== null) {
-        plotDiv.innerHTML = "error fetching chart data"
-      } else {
-        for (var i = 0; i < dataPoints.length; i++) { 
-          // convert timestamp to age in hours
-          dataPoints[i] = [(dataPoints[i][0] - submissionTime)/3600, dataPoints[i][1], 1]
-        }
-
-        upvoteRateData = dataPoints
-        upvoteRatePlot()
-      }
-    }
-  )
+function prepareUpvoteRatePlotData(dataPoints, submissionTime) {
+  return dataPoints.map((dataPoint, i) => [(dataPoints[i][0] - submissionTime)/3600, dataPoints[i][3], 1])
 }
 
-function upvoteRatePlot() {
+function upvoteRatePlot(upvoteRatePlotData, submissionTime, startTime, endTime) {
 
   var plotDiv = document.getElementById('upvoterate_plot_div')
 
@@ -35,7 +11,7 @@ function upvoteRatePlot() {
   data.addColumn('number', 'Estimated True Upvote Rate');
   data.addColumn('number', 'Expected Upvote Rate');
 
-  data.addRows(upvoteRateData);
+  data.addRows(prepareUpvoteRatePlotData(upvoteRatePlotData, submissionTime));
 
   var ageFormatter = new ageFormat()
   ageFormatter.format(data, 0);
@@ -47,7 +23,8 @@ function upvoteRatePlot() {
       title: 'Age [hours]',
       logScale: false,
       viewWindow: {
-        min: 0,
+        min: (startTime-submissionTime)/3600,
+        max: (endTime-submissionTime)/3600,
       }
     },
     vAxis: {
@@ -64,9 +41,9 @@ function upvoteRatePlot() {
 
     lineWidth: 3,
     colors: ['#0089F4',  'black'],
-    chartArea:{left:80,top:50, bottom: 80, right: 20},
+    chartArea:{left:80, top:50, bottom: 80, right: 80},
+    height: 350,
     legend: { position: 'bottom' },
-    height: 400,
     crosshair: { trigger: 'both' },
     title: "Upvote Rate",
   };

--- a/templates/upvotesPlot.js.tmpl
+++ b/templates/upvotesPlot.js.tmpl
@@ -1,47 +1,26 @@
-var upvotesData
+function prepareUpvotesPlotData(dataPoints, submissionTime) {
 
-function drawUpvotesPlot(submissionTime) {
+   var results = []
 
-  var plotDiv = document.getElementById('upvotes_plot_div')
-
-  if (upvotesData !== undefined) {
-    return upvotesPlot()
-  }
-
-  getJSON('/plots/upvotes.json?id={{.ID}}',
-    function(err, dataPoints) {
-      plotDiv.classList.remove("spinner")
-      if (err !== null) {
-        plotDiv.innerHTML = "error fetching chart data"
-      } else {
-
-
-
-        // Modify our dataset so that we only plot points immediately
-        // before or after a change. This way the plot looks more like a staircase
-        // where the line is horizontal until there is an upvote then jumps up. Then we
-        // only have diagonal lines where there is missing data.
-        var lastValue = null
-        for (var i = 0; i < dataPoints.length; i++) { 
-          var p = dataPoints[i]
-
-          p[0] = (p[0] - submissionTime)/3600
-
-          if ( p[1] != lastValue || i+1 == dataPoints.length || p[1] != dataPoints[i+1][1] )  {
-            lastValue = p[1]
-          } else {
-            p[1] = null
-          }
-        }
-
-        upvotesData = dataPoints
-        upvotesPlot()
-      }
-    }
-  )
+   // Modify our dataset so that we only plot points immediately
+   // before or after a change. This way the plot looks more like a staircase
+   // where the line is horizontal until there is an upvote then jumps up. Then we
+   // only have diagonal lines where there is missing data.
+   var lastValue = null
+   for (var i = 0; i < dataPoints.length; i++) { 
+     var p = dataPoints[i]
+     var upvotes = p[1]
+     if ( upvotes != lastValue || i+1 == dataPoints.length || upvotes != dataPoints[i+1][1] )  {
+       lastValue = upvotes
+     } else {
+       upvotes = null
+     }
+     results[i] = [(p[0] - submissionTime)/3600, upvotes, p[2]]
+   }
+   return results;
 }
 
-function upvotesPlot() {
+function upvotesPlot(upvotesData, submissionTime, startTime, endTime) {
 
   var plotDiv = document.getElementById('upvotes_plot_div')
 
@@ -50,7 +29,7 @@ function upvotesPlot() {
   data.addColumn('number', 'Upvotes');
   data.addColumn('number', 'Expected Upvotes');
 
-  data.addRows(upvotesData);
+  data.addRows(prepareUpvotesPlotData(upvotesData, submissionTime));
 
   var ageFormatter = new ageFormat()
   ageFormatter.format(data, 0);
@@ -62,7 +41,8 @@ function upvotesPlot() {
       title: 'Age [hours]',
       logScale: false,
       viewWindow: {
-        min: 0,
+        min: (startTime-submissionTime)/3600,
+        max: (endTime-submissionTime)/3600,
       }
     },
     vAxis: {
@@ -79,9 +59,9 @@ function upvotesPlot() {
     interpolateNulls: true, 
 
     colors: ['#55cccc', 'black'],
-    chartArea:{left:80,top:50, bottom: 80, right: 20},
+    chartArea:{left:80, top:50, bottom: 80, right: 80},
+    height: 350,
     legend: { position: 'bottom' },
-    height: 400,
     crosshair: { trigger: 'both' },
     title: "Upvotes",
   };


### PR DESCRIPTION
- Change penalty weight to 1.0 (#75)
- Increase crawler timeouts to 20-30 seconds
- Refactor plots to include plot data JSON in initial request
- Fix penalty calculation to use (re)submissionTime not original submission time for resubmitted stories (#75)
- Don't calculate penalty for resubmitted stories (#75)
- Add LISTEN_ADDRESS env variables and set to 127.0.0.1 by default (dev environments)
